### PR TITLE
Add CLI args to Minesweeper

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,17 @@ This repository contains a simple command-line Minesweeper game written in Pytho
 
 ## How to run
 
-Execute the script using Python 3:
+Execute the script using Python 3. You can optionally specify the board size and
+number of mines:
 
 ```
-python minesweeper.py
+python minesweeper.py [--rows N] [--cols N] [--mines N]
+```
+
+For example, to play on a 12×10 board with 20 mines:
+
+```
+python minesweeper.py --rows 12 --cols 10 --mines 20
 ```
 
 During the game use the following commands:

--- a/minesweeper.py
+++ b/minesweeper.py
@@ -1,4 +1,5 @@
 import random
+import argparse
 from typing import List
 
 
@@ -90,7 +91,13 @@ class Minesweeper:
 
 
 def main():
-    game = Minesweeper()
+    parser = argparse.ArgumentParser(description="Play Minesweeper on the command line")
+    parser.add_argument("--rows", type=int, default=9, help="number of rows")
+    parser.add_argument("--cols", type=int, default=9, help="number of columns")
+    parser.add_argument("--mines", type=int, default=10, help="number of mines")
+    args = parser.parse_args()
+
+    game = Minesweeper(rows=args.rows, cols=args.cols, mines=args.mines)
     while True:
         game.display()
         cmd = input("Enter command (r row col: reveal, f row col: flag): ").strip().split()


### PR DESCRIPTION
## Summary
- allow customizing board size and mine count via `--rows`, `--cols`, and `--mines`
- document usage of these arguments in README

## Testing
- `python -m py_compile minesweeper.py`
- `python minesweeper.py --rows 5 --cols 5 --mines 3 <<EOF
r 0 0
EOF` *(fails at EOF as expected)*

------
https://chatgpt.com/codex/tasks/task_e_684162753ff88333865afeefe21e2bae